### PR TITLE
change handler/internal to handler/inner to avoid package name conflict in golang 1.5+

### DIFF
--- a/handler/inner/dataserver.go
+++ b/handler/inner/dataserver.go
@@ -1,4 +1,4 @@
-package internal
+package inner
 
 import (
 	"net/http"

--- a/router/router.go
+++ b/router/router.go
@@ -5,7 +5,7 @@ import (
 	"gopkg.in/macaron.v1"
 
 	"github.com/containerops/arkor/handler"
-	"github.com/containerops/arkor/handler/internal"
+	"github.com/containerops/arkor/handler/inner"
 	"github.com/containerops/arkor/models"
 )
 
@@ -20,7 +20,7 @@ func SetRouters(m *macaron.Macaron) {
 	// internal APIS
 	m.Group("/internal", func() {
 		m.Group("/v1", func() {
-			m.Put("/dataserver", binding.Bind(models.DataServer{}), internal.PutDataserverHandler)
+			m.Put("/dataserver", binding.Bind(models.DataServer{}), inner.PutDataserverHandler)
 		})
 	})
 	// interface to test whether the arkor is working


### PR DESCRIPTION

Signed-off-by: Wang Qilin <qilin.wang@huawei.com>