### PR TITLE
Add the APIs: /internal/v1/dataserver, /internal/v1/groups

### DIFF
--- a/handler/inner/dataserver.go
+++ b/handler/inner/dataserver.go
@@ -8,6 +8,7 @@ import (
 	"gopkg.in/macaron.v1"
 
 	"github.com/containerops/arkor/models"
+	"github.com/containerops/arkor/utils"
 	"github.com/containerops/arkor/utils/db"
 )
 
@@ -38,6 +39,36 @@ func PutDataserverHandler(ctx *macaron.Context, req models.DataServer, log *logr
 		log.Println(err.Error())
 		return http.StatusInternalServerError, []byte(err.Error())
 	}
+
+	return http.StatusOK, nil
+}
+
+func AddDataserverHandler(ctx *macaron.Context, req models.DataServer, log *logrus.Logger) (int, []byte) {
+	now := time.Now()
+
+	ds := &models.DataServer{
+		ID:         utils.MD5ID(),
+		GroupID:    req.GroupID,
+		IP:         req.IP,
+		Port:       req.Port,
+		CreateTime: now,
+		UpdateTime: now,
+	}
+
+	// Query DataServer ID from SQL Database
+	if err := db.SQLDB.Create(ds); err != nil {
+		log.Println(err.Error())
+		return http.StatusInternalServerError, []byte(err.Error())
+	}
+
+	log.Println(ds)
+	// Save dataserver status to K/V Database
+	if err := db.KVDB.Create(ds); err != nil {
+		log.Println(err.Error())
+		return http.StatusInternalServerError, []byte(err.Error())
+	}
+
+	// Save dataserver status to SQL Database
 
 	return http.StatusOK, nil
 }

--- a/handler/inner/dataserver.go
+++ b/handler/inner/dataserver.go
@@ -1,6 +1,7 @@
 package inner
 
 import (
+	"encoding/json"
 	"net/http"
 	"time"
 
@@ -45,9 +46,10 @@ func PutDataserverHandler(ctx *macaron.Context, req models.DataServer, log *logr
 
 func AddDataserverHandler(ctx *macaron.Context, req models.DataServer, log *logrus.Logger) (int, []byte) {
 	now := time.Now()
+	ServerID := utils.MD5ID()
 
 	ds := &models.DataServer{
-		ID:         utils.MD5ID(),
+		ID:         ServerID,
 		GroupID:    req.GroupID,
 		IP:         req.IP,
 		Port:       req.Port,
@@ -55,20 +57,56 @@ func AddDataserverHandler(ctx *macaron.Context, req models.DataServer, log *logr
 		UpdateTime: now,
 	}
 
-	// Query DataServer ID from SQL Database
+	// Create dataserver in SQL Database
 	if err := db.SQLDB.Create(ds); err != nil {
 		log.Println(err.Error())
 		return http.StatusInternalServerError, []byte(err.Error())
 	}
 
 	log.Println(ds)
-	// Save dataserver status to K/V Database
+	// Save dataserver info to K/V Database as cache
 	if err := db.KVDB.Create(ds); err != nil {
 		log.Println(err.Error())
 		return http.StatusInternalServerError, []byte(err.Error())
 	}
 
-	// Save dataserver status to SQL Database
+	gs := &models.GroupServer{
+		GroupID:  req.GroupID,
+		ServerID: ServerID,
+	}
+
+	if err := db.SQLDB.Create(gs); err != nil {
+		return http.StatusInsufficientStorage, []byte(err.Error())
+	}
 
 	return http.StatusOK, nil
+}
+
+func GetGroupsHandler(ctx *macaron.Context, log *logrus.Logger) (int, []byte) {
+
+	relations := []models.GroupServer{}
+
+	if _, err := db.SQLDB.QueryMulti(&models.GroupServer{}, &relations); err != nil {
+		log.Println(err.Error())
+		return http.StatusInternalServerError, []byte(err.Error())
+	}
+
+	groups := make(map[string][]string)
+
+	for _, relation := range relations {
+		if _, exists := groups[relation.GroupID]; exists == true {
+			groups[relation.GroupID] = append(groups[relation.GroupID], relation.ServerID)
+		} else {
+			groups[relation.GroupID] = []string{relation.ServerID}
+		}
+	}
+
+	result, err := json.Marshal(groups)
+	if err != nil {
+		return http.StatusInternalServerError, []byte(err.Error())
+	}
+
+	ctx.Resp.Header().Set("Content-Type", "application/json")
+
+	return http.StatusOK, result
 }

--- a/models/dataserver.go
+++ b/models/dataserver.go
@@ -15,9 +15,9 @@ const (
 // struct of DataServer
 type DataServer struct {
 	ID             string    `json:"dataServerID,omitempty" gorm:"unique;column:id"`
-	GroupID        string    `json:"groupID,omitempty" gorm:"column:group_id"`
-	IP             string    `json:"ip,omitempty" gorm:"column:ip"`
-	Port           int       `json:"port,omitempty"`
+	GroupID        string    `json:"groupID,omitempty" gorm:"column:group_id" binding:"Required"`
+	IP             string    `json:"ip,omitempty" gorm:"column:ip" binding:"Required"`
+	Port           int       `json:"port,omitempty" binding:"Required"`
 	Status         int       `json:"status,omitempty"`
 	Deleted        int       `json:"deleted,omitempty"`
 	TotalChunks    int       `json:"total_chunks,omitempty"`

--- a/models/group.go
+++ b/models/group.go
@@ -11,3 +11,9 @@ type Group struct {
 	GroupStatus int          `json:"globalStatus,omitempty"`
 	Servers     []DataServer `json:"servers,omitempty"`
 }
+
+type GroupServer struct {
+	ID       int    `json:"id,omitempty" gorm:"primary_key:true;AUTO_INCREMENT"`
+	GroupID  string `json:"groupID,omitempty"`
+	ServerID string `json:"serverID,omitempty"`
+}

--- a/router/router.go
+++ b/router/router.go
@@ -22,6 +22,7 @@ func SetRouters(m *macaron.Macaron) {
 		m.Group("/v1", func() {
 			m.Post("/dataserver", binding.Bind(models.DataServer{}), inner.AddDataserverHandler)
 			m.Put("/dataserver", binding.Bind(models.DataServer{}), inner.PutDataserverHandler)
+			m.Get("/groups", inner.GetGroupsHandler)
 		})
 	})
 	// interface to test whether the arkor is working

--- a/router/router.go
+++ b/router/router.go
@@ -20,6 +20,7 @@ func SetRouters(m *macaron.Macaron) {
 	// internal APIS
 	m.Group("/internal", func() {
 		m.Group("/v1", func() {
+			m.Post("/dataserver", binding.Bind(models.DataServer{}), inner.AddDataserverHandler)
 			m.Put("/dataserver", binding.Bind(models.DataServer{}), inner.PutDataserverHandler)
 		})
 	})

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"math/rand"
 	"os"
 	"reflect"
 	"regexp"
@@ -107,6 +108,16 @@ func MD5(key string) string {
 	h.Write([]byte(md5String))
 
 	return hex.EncodeToString(h.Sum(nil))
+}
+
+/*
+Get a unique ID by passing a random string into MD5
+*/
+func MD5ID() string {
+	src := rand.NewSource(time.Now().UnixNano())
+	r := rand.New(src)
+	s := fmt.Sprintf("%d", r.Int63())
+	return MD5(s)
 }
 
 func Compare(a, b string) int {

--- a/web/web.go
+++ b/web/web.go
@@ -37,7 +37,7 @@ func InitSQLDB() {
 		if err != nil {
 			fmt.Printf("Connect database error: %s\n", err.Error())
 		}
-		db.SQLDB.RegisterModel(&models.DataServer{}, &models.Bucket{}, &models.Content{}, &models.Owner{})
+		db.SQLDB.RegisterModel(&models.DataServer{}, &models.Bucket{}, &models.Content{}, &models.Owner{}, &models.GroupServer{})
 	}
 }
 


### PR DESCRIPTION
The PR provide the two APIs:
POST /internal/v1/dataserver, which creates a new data server and the group-dataserver relation
GET /internal/v1/groups, which returns all the groups' info(each group contains some data servers)