### PR TITLE
API: Get/Delete data server, get group info

### DIFF
--- a/docs/specs/Internal.md
+++ b/docs/specs/Internal.md
@@ -290,7 +290,7 @@ Content-Type: application/json
 ```json
 {
   "id": "1",
-  "groupStatus": "0",
+  "group_status": "0",
   "servers": [
     {
       "data_server_id": "as89ik",

--- a/docs/specs/Internal.md
+++ b/docs/specs/Internal.md
@@ -121,7 +121,7 @@ Date: date
 #### Response On Failure
 
 * 400 - Bad Request (Invalid Parameters)
-* 404 - Not Found (Data server have NOT registered)
+* 404 - Not Found (Data server is NOT registered)
 * 409 - Conflict (Data Server already deleted)
 * 500 - Internal Server Error
 
@@ -194,7 +194,7 @@ Content-Type: application/json
 #### Response On Failure
 
 * 400 - Bad Request (Invalid Parameters)
-* 404 - Not Found (Data server have NOT registered)
+* 404 - Not Found (Data server is NOT registered)
 * 409 - Conflict (Data Server already deleted)
 * 500 - Internal Server Error
 
@@ -255,7 +255,7 @@ Date: date
 #### Response On Failure
 
 * 400 - Bad Request (Invalid Parameters)
-* 404 - Not Found (Data server have NOT registered)
+* 404 - Not Found (Data server is NOT registered)
 * 409 - Conflict (Data Server already deleted)
 * 500 - Internal Server Error
 

--- a/handler/inner/dataserver.go
+++ b/handler/inner/dataserver.go
@@ -23,7 +23,7 @@ func PutDataserverHandler(ctx *macaron.Context, req models.DataServer, log *logr
 
 	// Query DataServer ID from SQL Database
 	if exist, err := db.SQLDB.Query(ds); !exist && err == nil {
-		return http.StatusNotFound, []byte("Data server have NOT registered")
+		return http.StatusNotFound, []byte("Data server is NOT registered")
 	} else if err != nil {
 		return http.StatusInternalServerError, []byte(err.Error())
 	}
@@ -123,11 +123,11 @@ func DeleteDataserverHandler(ctx *macaron.Context, log *logrus.Logger) (int, []b
 	}
 
 	if err := db.KVDB.Delete(ds); err != nil {
-		return http.StatusInternalServerError, nil
+		return http.StatusInternalServerError, []byte(err.Error())
 	}
 
 	if err := db.SQLDB.Delete(ds); err != nil {
-		return http.StatusInternalServerError, nil
+		return http.StatusInternalServerError, []byte(err.Error())
 	}
 
 	return http.StatusOK, nil
@@ -148,9 +148,9 @@ func GetDataserverHandler(ctx *macaron.Context, log *logrus.Logger) (int, []byte
 
 	// If there is no info in cache, try to fetch it from SQLDB and rebuild the cache
 	if exist, err := db.SQLDB.Query(ds); !exist && err == nil {
-		return http.StatusNotFound, []byte("Data server NOT found")
+		return http.StatusNotFound, []byte("Data server is NOT registered")
 	} else if err != nil {
-		return http.StatusInternalServerError, nil
+		return http.StatusInternalServerError, []byte(err.Error())
 	}
 	db.KVDB.Create(ds)
 

--- a/handler/inner/dataserver.go
+++ b/handler/inner/dataserver.go
@@ -80,7 +80,15 @@ func AddDataserverHandler(ctx *macaron.Context, req models.DataServer, log *logr
 		return http.StatusInsufficientStorage, []byte(err.Error())
 	}
 
-	return http.StatusOK, nil
+	dsObj := make(map[string]interface{})
+	dsObj["ip"] = ds.IP
+	dsObj["port"] = ds.Port
+	dsObj["group_id"] = ds.GroupID
+
+	ctx.Resp.Header().Set("Content-Type", "application/json")
+	result, _ := json.Marshal([]interface{}{dsObj})
+
+	return http.StatusOK, result
 }
 
 func GetGroupsHandler(ctx *macaron.Context, log *logrus.Logger) (int, []byte) {

--- a/handler/inner/dataserver.go
+++ b/handler/inner/dataserver.go
@@ -51,6 +51,10 @@ func AddDataserverHandler(ctx *macaron.Context, log *logrus.Logger) (int, []byte
 	dataServers := []models.DataServer{}
 	json.Unmarshal(data, &dataServers)
 
+	if len(dataServers) == 0 {
+		return http.StatusBadRequest, []byte("Invalid Parameters or Incorrect json content")
+	}
+
 	insertDataServerSql := "INSERT INTO data_server (id, group_id, ip, port, create_time, update_time) VALUES "
 	insertGroupServerSql := "INSERT INTO group_server (group_id, server_id) VALUES "
 
@@ -89,7 +93,7 @@ func AddDataserverHandler(ctx *macaron.Context, log *logrus.Logger) (int, []byte
 		dsObj["group_id"] = dataServer.GroupID
 		dsObj["data_server_id"] = serverID
 
-		resultAry = append(ary, dsObj)
+		resultAry = append(resultAry, dsObj)
 	}
 
 	dbInstance := db.SQLDB.GetDB().(*gorm.DB)

--- a/handler/inner/dataserver.go
+++ b/handler/inner/dataserver.go
@@ -130,6 +130,12 @@ func DeleteDataserverHandler(ctx *macaron.Context, log *logrus.Logger) (int, []b
 		return http.StatusInternalServerError, []byte(err.Error())
 	}
 
+	whereClause := fmt.Sprintf("server_id=%q", dataserverID)
+
+	if result := db.SQLDB.GetDB().(*gorm.DB).Where(whereClause).Delete(models.GroupServer{}); result.Error != nil {
+		return http.StatusInternalServerError, []byte(result.Error.Error())
+	}
+
 	return http.StatusOK, nil
 }
 


### PR DESCRIPTION
New APIs:

-`GET /internal/v1/:dataserver`: get a particular data server's info
-`DELETE /internal/v1/:dataserver`: remove a registered data server
-`GET /internal/v1/groups/:group`: get a group's info