### PR TITLE
GET/PUT object APIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ arkor
 dataserver/spy_server
 conf/runtime.yaml
 conf/dataserver.yaml
+
+# IDEs' config folder
+.vscode

--- a/docs/specs/Internal.md
+++ b/docs/specs/Internal.md
@@ -535,9 +535,9 @@ Date: date
 
 ```json
 {
-  "objectID": "b06bd",
-  "objectKey": "test.tar",
-  "md5Key": "f1ddfa66735ab83451b8ec3bf9c0fe46",
+  "object_id": "b06bd",
+  "object_key": "test.tar",
+  "md5_key": "f1ddfa66735ab83451b8ec3bf9c0fe46",
   "fragments": [
     {
       "index": 0,
@@ -564,9 +564,9 @@ Date: date
 
 |Name|Type|Description|
 |----|----|-----------|
-|`objectID`|String|ID of the object|
-|`objectKey`|String|Key(name) of the object|
-|`md5key`|String|MD5 value of the object key|
+|`object_id`|String|ID of the object|
+|`object_key`|String|Key(name) of the object|
+|`md5_key`|String|MD5 value of the object key|
 |`fragments`|container|Fragements info of the object|
 |`index`|Int|The sequence number of the fragment|
 |`start`|Int64|Where this fragement range starts|
@@ -618,9 +618,9 @@ Date: date
 ```
 ```json
 {
-  "objectID": "b06bd",
-  "objectKey": "test.tar",
-  "md5Key": "f1ddfa66735ab83451b8ec3bf9c0fe46",
+  "object_id": "b06bd",
+  "object_key": "test.tar",
+  "md5_key": "f1ddfa66735ab83451b8ec3bf9c0fe46",
   "fragments": [
     {
       "index": 0,
@@ -647,9 +647,9 @@ Date: date
 
 |Name|Type|Description|
 |----|----|-----------|
-|`objectID`|String|ID of the object|
-|`objectKey`|String|Key(name) of the object|
-|`md5key`|String|MD5 value of the object key|
+|`object_id`|String|ID of the object|
+|`object_key`|String|Key(name) of the object|
+|`md5_key`|String|MD5 value of the object key|
 |`fragments`|container|Fragements info of the object|
 |`index`|Int|The sequence number of the fragment|
 |`start`|Int64|Where this fragement range starts|

--- a/handler/inner/object.go
+++ b/handler/inner/object.go
@@ -2,12 +2,16 @@ package inner
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/jinzhu/gorm"
 	"gopkg.in/macaron.v1"
 
 	"github.com/containerops/arkor/utils"
+	"github.com/containerops/arkor/utils/db"
 )
 
 func AllocateFileID(ctx *macaron.Context, log *logrus.Logger) (int, []byte) {
@@ -19,5 +23,140 @@ func AllocateFileID(ctx *macaron.Context, log *logrus.Logger) (int, []byte) {
 		return http.StatusInternalServerError, []byte(err.Error())
 	}
 
+	return http.StatusOK, result
+}
+
+func PutObjectInfoHandler(ctx *macaron.Context, log *logrus.Logger) (int, []byte) {
+	data, _ := ctx.Req.Body().Bytes()
+	reqBody := make(map[string]interface{})
+	json.Unmarshal(data, &reqBody)
+	fragments := reqBody["fragments"].([]interface{})
+
+	if len(fragments) == 0 {
+		return http.StatusBadRequest, []byte("Invalid Parameters")
+	}
+
+	dbInstance := db.SQLDB.GetDB().(*gorm.DB)
+
+	object_id := reqBody["object_id"].(string)
+	object_key := reqBody["object_key"].(string)
+	md5_key := reqBody["md5_key"].(string)
+
+	// Remove the old relations
+	if result := dbInstance.Exec("DELETE FROM object WHERE object_id='" + object_id + "'"); result.Error != nil {
+		log.Errorln(result.Error.Error())
+		return http.StatusInternalServerError, []byte("Internal Server Error")
+	}
+
+	// Save ObjectMeta
+	insertOrUpdateSQL := fmt.Sprintf("REPLACE INTO object_meta(id, object_key, md5_key) VALUES(%q, %q, %q)", object_id, object_key, md5_key)
+	if result := dbInstance.Exec(insertOrUpdateSQL); result.Error != nil {
+		log.Errorln(result.Error.Error())
+		return http.StatusInternalServerError, []byte("Internal Server Error")
+	}
+
+	// Save fragments and the relation
+	insertFragmentsSQL := "INSERT INTO fragment(id, `index`, start, end, group_id, file_id, is_last, mod_time) VALUES "
+	insertRelationsSQL := "REPLACE INTO object(object_id, fragment_id) VALUES "
+
+	for index := range fragments {
+		f := fragments[index].(map[string]interface{})
+
+		fragmentID := utils.MD5ID()
+		index := int(f["index"].(float64))
+		start := int64(f["start"].(float64))
+		end := int64(f["end"].(float64))
+		group_id := f["group_id"].(string)
+		file_id := f["file_id"].(string)
+		is_last := f["is_last"].(bool)
+
+		modTimeStr := f["mod_time"].(string)
+		t, err := time.Parse("2006-01-02T15:04:05Z", modTimeStr)
+		if err != nil {
+			log.Errorln(err.Error())
+			return http.StatusBadRequest, []byte("Invalid Parameters")
+		}
+		mod_time := t.Format("2006-01-02 15:04:05")
+
+		insertFragmentSQL := fmt.Sprintf("(%q,%d,%d,%d,%q,%q,%t,%q),", fragmentID, index, start, end, group_id, file_id, is_last, mod_time)
+		insertFragmentsSQL += insertFragmentSQL
+
+		insertRelationSQL := fmt.Sprintf("(%q,%q),", reqBody["object_id"], fragmentID)
+		insertRelationsSQL += insertRelationSQL
+	}
+
+	insertFragmentsSQL = insertFragmentsSQL[:len(insertFragmentsSQL)-1]
+	if result := db.SQLDB.GetDB().(*gorm.DB).Exec(insertFragmentsSQL); result.Error != nil {
+		log.Errorln(result.Error.Error())
+		return http.StatusInternalServerError, []byte("Internal Server Error")
+	}
+
+	insertRelationsSQL = insertRelationsSQL[:len(insertRelationsSQL)-1]
+	if result := db.SQLDB.GetDB().(*gorm.DB).Exec(insertRelationsSQL); result.Error != nil {
+		log.Errorln(result.Error.Error())
+		return http.StatusInternalServerError, []byte("Internal Server Error")
+	}
+
+	return http.StatusOK, nil
+}
+
+func GetObjectInfoHandler(ctx *macaron.Context, log *logrus.Logger) (int, []byte) {
+	objectID := ctx.Params(":object")
+
+	sql := fmt.Sprintf(
+		"SELECT object.object_id, object.fragment_id, object_key, md5_key, `index`, start, end, group_id, file_id, is_last, mod_time FROM object, object_meta, fragment WHERE object_meta.id=%q AND object.object_id=%q  AND fragment.id=object.fragment_id",
+		objectID, objectID)
+
+	dbInstace := db.SQLDB.GetDB().(*gorm.DB)
+
+	rows, err := dbInstace.Raw(sql).Rows()
+	if err != nil {
+		return http.StatusInternalServerError, []byte("Internal Server Error")
+	}
+
+	defer rows.Close()
+
+	object := make(map[string]interface{})
+	fragments := []interface{}{}
+	for rows.Next() {
+		var object_id string
+		var fragment_id string
+		var object_key string
+		var md5_key string
+		var index int
+		var start int64
+		var end int64
+		var group_id string
+		var file_id string
+		var is_last bool
+		var mod_time string
+
+		rows.Scan(&object_id, &fragment_id, &object_key, &md5_key, &index, &start, &end, &group_id, &file_id, &is_last, &mod_time)
+
+		object["object_id"] = object_id
+		object["md5_key"] = md5_key
+		object["object_key"] = object_key
+
+		fragment := make(map[string]interface{})
+		fragment["index"] = index
+		fragment["start"] = start
+		fragment["end"] = end
+		fragment["group_id"] = group_id
+		fragment["file_id"] = file_id
+		fragment["is_last"] = is_last
+		fragment["mod_time"] = mod_time
+
+		fragments = append(fragments, fragment)
+	}
+	object["fragments"] = fragments
+
+	result, err := json.Marshal(object)
+
+	if err != nil {
+		log.Errorln(err.Error())
+		return http.StatusInternalServerError, []byte("Internal Server Error")
+
+	}
+	ctx.Resp.Header().Set("Content-Type", "application/json")
 	return http.StatusOK, result
 }

--- a/middleware/logger.go
+++ b/middleware/logger.go
@@ -27,12 +27,12 @@ func InitLog() {
 func logger(runmode string) macaron.Handler {
 	if strings.EqualFold(runmode, "dev") {
 		return func(ctx *macaron.Context) {
-			body, _ := ctx.Req.Body().String()
+			// body, _ := ctx.Req.Body().String()
 			Log.WithFields(logrus.Fields{
 				"[Method]":        ctx.Req.Method,
 				"[RequestHeader]": ctx.Req.Header,
 				"[Path]":          ctx.Req.RequestURI,
-				"[Body]":          body,
+				// "[Body]":          body,
 			}).Info("Request Received")
 		}
 	}

--- a/models/object.go
+++ b/models/object.go
@@ -5,18 +5,25 @@ import (
 )
 
 type ObjectMeta struct {
-	ID        string     `json:"object_id,omitempty"`
-	Key       string     `json:"object_key,omitempty"`
-	Md5Key    string     `json:"md5Key,omitempty"`
-	Fragments []Fragment `json:"fragments,omitempty"`
+	ID     string `json:"object_id,omitempty" gorm:"column:id;primary_key;unique"`
+	Key    string `json:"object_key,omitempty" gorm:"column:object_key"`
+	Md5Key string `json:"md5_key,omitempty" gorm:"column:md5_key`
+	// Fragments []Fragment `json:"fragments,omitempty"`
 }
 
 type Fragment struct {
-	Index   int       `json:"index,omitempty"`
+	ID      string    `json:"id" gorm:"column:id;primary_key;unique"`
+	Index   int       `json:"index,omitempty" gorm:"column:index"`
 	Start   int64     `json:"start,omitempty"`
 	End     int64     `json:"end,omitempty"`
 	GroupID string    `json:"group_id,omitempty"`
 	FileID  string    `json:"file_id,omitempty"`
 	IsLast  bool      `json:"is_last,omitempty"`
 	ModTime time.Time `json:"mod_time,omitempty"`
+}
+
+// Object :The relation of ObjectMeta and Fragment
+type Object struct {
+	ObjectID   string `json:"object_id" gorm:"primary_key"`
+	FragmentID string `json:"fragment_id" gorm:"primary_key"`
 }

--- a/router/router.go
+++ b/router/router.go
@@ -27,6 +27,8 @@ func SetRouters(m *macaron.Macaron) {
 			m.Get("/groups", inner.GetGroupsHandler)
 			m.Get("/groups/:group", inner.GetGroupHandler)
 			m.Get("/object/id", inner.AllocateFileID)
+			m.Put("/object/info", inner.PutObjectInfoHandler)
+			m.Get("/object/:object", inner.GetObjectInfoHandler)
 		})
 	})
 	// interface to test whether the arkor is working

--- a/web/web.go
+++ b/web/web.go
@@ -37,7 +37,7 @@ func InitSQLDB() {
 		if err != nil {
 			fmt.Printf("Connect database error: %s\n", err.Error())
 		}
-		db.SQLDB.RegisterModel(&models.DataServer{}, &models.Bucket{}, &models.Content{}, &models.Owner{}, &models.GroupServer{})
+		db.SQLDB.RegisterModel(&models.DataServer{}, &models.Bucket{}, &models.Content{}, &models.Owner{}, &models.GroupServer{}, &models.Object{}, &models.ObjectMeta{}, &models.Fragment{})
 	}
 }
 


### PR DESCRIPTION
The following APIs are added:

-`GET /internal/v1/object/:object`: Get an object's info
-`PUT /internal/v1/object`: Create or update an object

Additional:
- Comment the logging of request body, since it can be fetched only once, if the logger prints the body, the following handlers/middlewares won't  be able to get it.